### PR TITLE
Improve JSON.parse sink detection

### DIFF
--- a/postMessageTracker-Current/postMessage-tracker-modified/chrome/content_script.js
+++ b/postMessageTracker-Current/postMessage-tracker-modified/chrome/content_script.js
@@ -167,8 +167,8 @@ var injectedJS = function(pushstate, msgeventlistener, msgporteventlistener) {
                     taintedVariables.add(assignmentMatch[1]);
                 }
             }
-            // New: Add variables initialized with JSON.parse(event.data)
-            const jsonParseRegex = new RegExp('(?:var|let|const)\\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\\s*=\\s*JSON\\.parse\\(\\s*' + dataParameterForRegex + '\\s*\\)\\s*;', 'g');
+            // Track variables initialized with JSON.parse(event.data) even without declarations
+            const jsonParseRegex = new RegExp('(?:var|let|const)?\\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\\s*=\\s*JSON\\.parse\\(\\s*' + dataParameterForRegex + '\\s*\\)\\s*;?', 'g');
             let jsonMatch;
             while((jsonMatch = jsonParseRegex.exec(listener_str)) !== null) {
                 if (jsonMatch[1]) {
@@ -191,7 +191,8 @@ var injectedJS = function(pushstate, msgeventlistener, msgporteventlistener) {
             setIntervalString: /setInterval\s*\(\s*(['"`]|(?:[a-zA-Z_$][a-zA-Z0-9_$]*\s*(?!\()))[^,]*,\s*\d+\s*\)(?:;|$)/g,
             locationAssignment: /(?:[^a-zA-Z0-9_]|^)location\s*(?:\.href|\.assign|\.replace)?\s*=[^;]+(?:;|$)/g,
             scriptSrcViaCreateElement: /document\.createElement\s*\(\s*['"]script['"]\s*\)[^;]*\.src\s*=[^;]+(?:;|$)/g,
-            aHrefJS: /document\.createElement\s*\(\s*['"]a['"]\s*\)[^;]*\.href\s*=\s*['"`]javascript:/ig
+            aHrefJS: /document\.createElement\s*\(\s*['"]a['"]\s*\)[^;]*\.href\s*=\s*['"`]javascript:/ig,
+            jsonParse: /JSON\.parse\s*\([^)]+\)/g
         };
         for (const sinkType in sinkRegexes) {
             let match;


### PR DESCRIPTION
## Summary
- Detect variables assigned from `JSON.parse(event.data)` even when declared separately
- Flag `JSON.parse` calls as potential postMessage sinks

## Testing
- `node --check postMessageTracker-Current/postMessage-tracker-modified/chrome/content_script.js && echo "syntax ok"`

------
https://chatgpt.com/codex/tasks/task_e_689f64e197f4832fbda5518ab41e1828